### PR TITLE
V0.6.0

### DIFF
--- a/builds/empty_borge.yaml
+++ b/builds/empty_borge.yaml
@@ -54,6 +54,7 @@ mods:
 
 relics:
   disk_of_dawn: 0
+  long_range_artillery_crawler: 0
 
 gems:
   attraction_gem: 0

--- a/builds/empty_ozzy.yaml
+++ b/builds/empty_ozzy.yaml
@@ -49,6 +49,7 @@ mods: {}
 
 relics:
   disk_of_dawn: 0
+  bee_gone_companion_drone: 0
 
 gems:
   attraction_gem: 0

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -496,6 +496,7 @@ class Borge(Hunter):
         self.total_crits: int = 0
         self.total_extra_from_crits: float = 0
         self.total_helltouch: float = 0
+        self.helltouch_kills: int = 0
 
         # sustain
         self.total_loth: float = 0
@@ -897,6 +898,7 @@ class Borge(Hunter):
             'crits': self.total_crits,
             'extra_damage_from_crits': self.total_extra_from_crits,
             'helltouch_barrier': self.total_helltouch,
+            'helltouch_kills': self.helltouch_kills,
             'life_of_the_hunt_healing': self.total_loth,
             'unfair_advantage_healing': self.total_potion,
         }

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -148,7 +148,7 @@ class Hunter:
         self.talents = config_dict["talents"]
         self.attributes = config_dict["attributes"]
         self.mods = config_dict["mods"]
-        self.inscryptions = config_dict["inscryptions"]
+        self.inscryptions = {k: self.costs["inscryptions"][k]["max"] if v == "max" else v for k, v in config_dict["inscryptions"].items()}
         self.relics = config_dict["relics"]
         self.gems = config_dict["gems"]
 
@@ -443,6 +443,48 @@ class Borge(Hunter):
                 "max": 3,
             },
         },
+        "inscryptions": {
+            "i3": { # +6 hp
+                "cost": 1,
+                "max": 8,
+            },
+            "i4": { # +0.0065 crit chance
+                "cost": 1,
+                "max": 6,
+            },
+            "i11": { # +0.02 effect chance
+                "cost": 1,
+                "max": 3,
+            },
+            "i13": { # +8 power
+                "cost": 1,
+                "max": 8,
+            },
+            "i14": { # +1.1 loot
+                "cost": 1,
+                "max": 5,
+            },
+            "i23": { # -0.04 speed
+                "cost": 1,
+                "max": 5,
+            },
+            "i24": { # +0.004 damage reduction
+                "cost": 1,
+                "max": 8,
+            },
+            "i27": { # +24 hp
+                "cost": 1,
+                "max": 10,
+            },
+            "i44": { # +1.08 loot
+                "cost": 1,
+                "max": 10,
+            },
+            "i60": { # +0.03 hp, power, loot
+                "cost": 1,
+                "max": 10,
+            },
+        },
     }
 
     def __init__(self, config_dict: Dict):
@@ -494,6 +536,7 @@ class Borge(Hunter):
             )
             * (1 + (self.attributes["soul_of_ares"] * 0.002))
             * (1 + (self.inscryptions["i60"] * 0.03))
+            * (1 + (self.relics["long_range_artillery_crawler"] * 0.02))
             * (1 + (0.01 * (self.meta["level"] - 39)) * self.gems["creation_node_#3"])
             * (1 + (0.02 * self.gems["creation_node_#2"]))
             * (1 + (0.03 * self.gems["innovation_node_#3"]))
@@ -862,7 +905,6 @@ class Borge(Hunter):
 
 class Ozzy(Hunter):
     ### SETUP
-
     costs = {
         "talents": {
             "death_is_my_companion": { # +1 revive, 80% of max hp
@@ -948,6 +990,32 @@ class Ozzy(Hunter):
                 "max": 4,
             },
         },
+        "inscryptions": {
+            "i31": { # +0.006 ozzy effect chance
+                "cost": 1,
+                "max": 10,
+            },
+            "i32": { # x1.5 ozzy loot
+                "cost": 1,
+                "max": 8,
+            },
+            "i33": { # x1.75 ozzy xp
+                "cost": 1,
+                "max": 6,
+            },
+            "i36": { # -0.03 ozzy speed
+                "cost": 1,
+                "max": 5,
+            },
+            "i37": { # +0.0111 ozzy dr
+                "cost": 1,
+                "max": 7,
+            },
+            "i40": { # +0.005 ozzy multistrike chance
+                "cost": 1,
+                "max": 10,
+            },
+        },
     }
 
     def __init__(self, config_dict: Dict):
@@ -999,6 +1067,7 @@ class Ozzy(Hunter):
                 + (self.base_stats["power"] * (0.3 + 0.01 * (self.base_stats["power"] // 10)))
             )
             * (1 + (self.attributes["exo_piercers"] * 0.012))
+            * (1 + (self.relics["bee-gone_companion_drone"] * 0.02))
             * (1 + (0.03 * self.gems["innovation_node_#3"]))
         )
         # regen
@@ -1355,5 +1424,7 @@ class Ozzy(Hunter):
 
 
 if __name__ == "__main__":
-    h = Hunter.from_file('builds/current_borge.yaml')
+    h = Hunter.from_file('builds/current_ozzy.yaml')
     h.show_build()
+    h.complete_stage(150)
+    print(h)

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -495,9 +495,9 @@ class Borge(Hunter):
                 + (self.base_stats["effect_chance"] * 0.005)
                 + (self.attributes["superior_sensors"] * 0.012)
                 + (self.inscryptions["i11"] * 0.02)
+                + (0.03 * self.gems["innovation_node_#3"])
             )
             * (1 + (0.02 * self.gems["creation_node_#2"]))
-            * (1 + (0.03 * self.gems["innovation_node_#3"]))
         )
         # special_chance
         self.special_chance = (
@@ -996,8 +996,8 @@ class Ozzy(Hunter):
                 0.05
                 + (self.base_stats["special_chance"] * 0.0038)
                 + (self.inscryptions["i40"] * 0.005)
+                + (0.03 * self.gems["innovation_node_#3"])
             )
-            * (1 + (0.03 * self.gems["innovation_node_#3"]))
         )
         # special_damage
         self.special_damage = (

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -1032,6 +1032,7 @@ class Ozzy(Hunter):
         self.total_ms_extra_damage: float = 0
         self.total_decay_damage: float = 0
         self.total_cripple_extra_damage: float = 0
+        self.medusa_kills: int = 0
 
         # sustain
         self.total_potion: float = 0
@@ -1419,6 +1420,7 @@ class Ozzy(Hunter):
             'trickster_evades': self.total_trickster_evades,
             'decay_damage': self.total_decay_damage,
             'extra_damage_from_crippling_strikes': self.total_cripple_extra_damage,
+            'medusa_kills': self.medusa_kills,
             'echo_bullets': self.total_echo,
         }
 

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -1084,7 +1084,7 @@ class Ozzy(Hunter):
                 + (self.base_stats["power"] * (0.3 + 0.01 * (self.base_stats["power"] // 10)))
             )
             * (1 + (self.attributes["exo_piercers"] * 0.012))
-            * (1 + (self.relics["bee-gone_companion_drone"] * 0.02))
+            * (1 + (self.relics["bee_gone_companion_drone"] * 0.02))
             * (1 + (0.03 * self.gems["innovation_node_#3"]))
         )
         # regen
@@ -1197,7 +1197,7 @@ class Ozzy(Hunter):
             },
             "relics": {
                 "disk_of_dawn": 0,
-                "bee-gone_companion_drone": 0,
+                "bee_gone_companion_drone": 0,
             },
             "gems": {
                 "attraction_gem": 0,

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -243,7 +243,7 @@ class Hunter:
         """Actions to take when the hunter kills an enemy. The Hunter() implementation only handles loot.
         """
         loot = self.compute_loot()
-        if self.current_stage % 100 != 0 and random.random() < self.effect_chance and (LL := self.talents["call_me_lucky_loot"]):
+        if (self.current_stage % 100 != 0 and self.current_stage > 0) and random.random() < self.effect_chance and (LL := self.talents["call_me_lucky_loot"]):
             # Talent: Call Me Lucky Loot, cannot proc on bosses
             loot *= 1 + (self.talents["call_me_lucky_loot"] * 0.2)
             self.total_effect_procs += 1
@@ -716,8 +716,6 @@ class Borge(Hunter):
             # Talent: Fires of War
             self.apply_fow()
             self.total_effect_procs += 1
-        if target.is_dead():
-            self.on_kill()
 
     def receive_damage(self, attacker, damage: float, is_crit: bool) -> None:
         """Receive damage from an attack. Accounts for damage reduction, evade chance and reflected damage.

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -3,6 +3,7 @@ import random
 from heapq import heappush as hpush
 from typing import Dict, List, Tuple
 
+import yaml
 from util.exceptions import BuildConfigError
 
 hunter_name_spacing: int = 7
@@ -58,6 +59,25 @@ class Hunter:
 
         # loot
         self.total_loot: float = 0
+
+    @classmethod
+    def from_file(cls, file_path: str) -> 'Hunter':
+        """Create a Hunter instance from a build config file.
+
+        Args:
+            file_path (str): The path to the build config file.
+
+        Returns:
+            Hunter: The Hunter instance.
+        """
+        with open(file_path, 'r') as f:
+            cfg = yaml.safe_load(f)
+        if cfg["meta"]["hunter"].lower() not in ["borge", "ozzy"]:
+            raise ValueError("hunter_sim.py: error: invalid hunter found in primary build config file. Please specify a valid hunter.")
+        if cls != Hunter:
+            return cls(cfg)
+        else:
+            return globals()[cfg["meta"]["hunter"].title()](cfg)
 
     def get_results(self) -> List:
         """Fetch the hunter results for end-of-run statistics.
@@ -1318,13 +1338,5 @@ class Ozzy(Hunter):
 
 
 if __name__ == "__main__":
-    b = Borge('builds/current_borge.yaml')
-    b.show_build()
-    # print(b)
-    # b.complete_stage(100)
-    # print(b)
-    # o = Ozzy('builds/current_ozzy.yaml')
-    # print(o)
-    # o.complete_stage(100)
-    # print(o)
-    
+    h = Hunter.from_file('builds/current_borge.yaml')
+    h.show_build()

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -585,10 +585,11 @@ class Borge(Hunter):
                 "i60": 0, # 0.03 borge hp, power, loot
             },
             "mods": {
-                "trample": False
+                "trample": False,
             },
             "relics": {
-                "disk_of_dawn": 0
+                "disk_of_dawn": 0,
+                "long_range_artillery_crawler": 0,
             },
             "gems": {
                 "attraction_gem": 0,
@@ -1072,7 +1073,8 @@ class Ozzy(Hunter):
             "mods": {
             },
             "relics": {
-                "disk_of_dawn": 0
+                "disk_of_dawn": 0,
+                "bee-gone_companion_drone": 0,
             },
             "gems": {
                 "attraction_gem": 0,

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -79,6 +79,23 @@ class Hunter:
         else:
             return globals()[cfg["meta"]["hunter"].title()](cfg)
 
+    def as_dict(self) -> dict:
+        """Create a build config dictionary from a loaded hunter instance.
+
+        Returns:
+            dict: The hunter build dict.
+        """
+        return {
+            "meta": self.meta,
+            "stats": self.base_stats,
+            "talents": self.talents,
+            "attributes": self.attributes,
+            "mods": self.mods,
+            "inscryptions": self.inscryptions,
+            "relics": self.relics,
+            "gems": self.gems,
+        }
+
     def get_results(self) -> List:
         """Fetch the hunter results for end-of-run statistics.
 

--- a/hunter-sim/hunters.py
+++ b/hunter-sim/hunters.py
@@ -316,12 +316,11 @@ class Hunter:
         Returns:
             str: The stats as a formatted string.
         """
-        return f'[{self.name:>{hunter_name_spacing}}]:\t[HP:{(str(round(self.hp, 2)) + "/" + str(round(self.max_hp, 2))):>18}] [AP:{self.power:>7.2f}] [Regen:{self.regen:>6.2f}] [DR: {self.damage_reduction:>6.4f}] [Evasion: {self.evade_chance:>6.4f}] [Effect: {self.effect_chance:>6.4f}] [SpC: {self.special_chance:>6.4f}] [SpD: {self.special_damage:>5.2f}] [Speed:{self.speed:>5.2f}] [LS: {self.lifesteal:>4.3f}]'
+        return f'[{self.name:>{hunter_name_spacing}}]:\t[HP:{(str(round(self.hp, 2)) + "/" + str(round(self.max_hp, 2))):>18}] [AP:{self.power:>8.2f}] [Regen:{self.regen:>7.2f}] [DR: {self.damage_reduction:>6.2%}] [Evasion: {self.evade_chance:>6.2%}] [Effect: {self.effect_chance:>6.2%}] [SpC: {self.special_chance:>6.2%}] [SpD: {self.special_damage:>5.2f}] [Speed:{self.speed:>5.2f}] [LS: {self.lifesteal:>4.2%}]'
 
 
 class Borge(Hunter):
     ### SETUP
-
     costs = {
         "talents": {
             "death_is_my_companion": { # +1 revive at 80% hp

--- a/hunter-sim/sim.py
+++ b/hunter-sim/sim.py
@@ -139,7 +139,7 @@ class SimulationManager():
             'offence': ['attacks', 'damage', 'crits', 'extra_damage_from_crits', 'multistrikes', 'extra_damage_from_ms', 'decay_damage', 'extra_damage_from_crippling_shots'],
             'sustain': ['damage_taken', 'regenerated_hp', 'attacks_suffered', 'lifesteal'],
             'defence': ['evades', 'trickster_evades', 'mitigated_damage'],
-            'effects': ['effect_procs', 'stun_duration_inflicted', 'helltouch_barrier', 'life_of_the_hunt_healing', 'echo_bullets', 'unfair_advantage_healing'],
+            'effects': ['effect_procs', 'stun_duration_inflicted', 'helltouch_barrier', 'helltouch_kills', 'medusa_kills', 'life_of_the_hunt_healing', 'echo_bullets', 'unfair_advantage_healing'],
             'loot': ['loot_per_hour'],
         }
         for k, v in output_format.items():

--- a/hunter-sim/sim.py
+++ b/hunter-sim/sim.py
@@ -382,8 +382,6 @@ class Simulation():
                     trample_kills = hunter.apply_trample(self.enemies)
                     if trample_kills > 0:
                         logging.debug(f'[{hunter.name:>7}]:\tTRAMPLE {trample_kills} enemies')
-                        hunter.total_kills += trample_kills
-                        hunter.total_attacks += 1
                         hunter.total_damage += trample_kills * hunter.power
                         self.enemies = [e for e in self.enemies if not e.is_dead()]
                         continue

--- a/hunter-sim/sim.py
+++ b/hunter-sim/sim.py
@@ -139,7 +139,7 @@ class SimulationManager():
             'offence': ['attacks', 'damage', 'crits', 'extra_damage_from_crits', 'multistrikes', 'extra_damage_from_ms', 'decay_damage', 'extra_damage_from_crippling_shots'],
             'sustain': ['damage_taken', 'regenerated_hp', 'attacks_suffered', 'lifesteal'],
             'defence': ['evades', 'trickster_evades', 'mitigated_damage'],
-            'effects': ['effect_procs', 'stun_duration_inflicted', 'helltouch_barrier', 'helltouch_kills', 'medusa_kills', 'life_of_the_hunt_healing', 'echo_bullets', 'unfair_advantage_healing'],
+            'effects': ['effect_procs', 'stun_duration_inflicted', 'helltouch_barrier', 'helltouch_kills', 'trample_kills', 'medusa_kills', 'life_of_the_hunt_healing', 'echo_bullets', 'unfair_advantage_healing'],
             'loot': ['loot_per_hour'],
         }
         for k, v in output_format.items():

--- a/hunter-sim/units.py
+++ b/hunter-sim/units.py
@@ -228,17 +228,22 @@ class Enemy:
     def on_death(self) -> None:
         """Executes on death effects. For enemy units, that is mostly just removing them from the sim queue and incrementing hunter kills.
         """
-        self.sim.hunter.total_kills += 1
         logging.debug(f"[{self.name:>{unit_name_spacing}}][@{self.sim.elapsed_time:>5}]:\tDIED")
         self.sim.queue = [(p1, p2, u) for p1, p2, u in self.sim.queue if u not in ['enemy', 'enemy_special']]
         heapify(self.sim.queue)
+        self.sim.hunter.total_kills += 1
+        self.sim.hunter.on_kill()
 
     def kill(self) -> None:
         """Kills the unit.
+
+        Currently only used for Trample, which is a guaranteed kill. on_death() is not called here to suppress logging,
+        and because the trampled units attacks are not queued yet, so this would take up unnecessary processing.
         """
         self.hp = 0
-        # not sure about this one yet
-        # self.on_death()
+        self.sim.hunter.total_kills += 1
+        self.sim.hunter.total_attacks += 1
+        self.sim.hunter.on_kill()
 
     ### UTILITY
 

--- a/hunter-sim/units.py
+++ b/hunter-sim/units.py
@@ -184,6 +184,8 @@ class Enemy:
             self.hp -= mitigated_damage
             logging.debug(f"[{self.name:>{unit_name_spacing}}][@{self.sim.elapsed_time:>5}]:\tTAKE\t{mitigated_damage:>6.2f}, {self.hp:.2f} HP left")
             if self.is_dead():
+                if is_reflected:
+                    self.sim.hunter.helltouch_kills += 1
                 self.on_death()
 
     def heal_hp(self, value: float, source: str) -> None:

--- a/hunter-sim/units.py
+++ b/hunter-sim/units.py
@@ -220,6 +220,14 @@ class Enemy:
         hpush(self.sim.queue, (qe[0] + duration, qe[1], qe[2]))
         logging.debug(f"[{self.name:>{unit_name_spacing}}][@{self.sim.elapsed_time:>5}]:\tSTUNNED\t{duration:>6.2f} sec")
 
+    def is_boss(self) -> bool:
+        """Check if the unit is a boss.
+
+        Returns:
+            bool: True if the unit is a boss, False otherwise.
+        """
+        return isinstance(self, Boss)
+
     def is_dead(self) -> bool:
         """Check if the unit is dead.
 
@@ -228,10 +236,11 @@ class Enemy:
         """
         return self.hp <= 0
 
-    def on_death(self) -> None:
+    def on_death(self, suppress_logging: bool = False) -> None:
         """Executes on death effects. For enemy units, that is mostly just removing them from the sim queue and incrementing hunter kills.
         """
-        logging.debug(f"[{self.name:>{unit_name_spacing}}][@{self.sim.elapsed_time:>5}]:\tDIED")
+        if not suppress_logging:
+            logging.debug(f"[{self.name:>{unit_name_spacing}}][@{self.sim.elapsed_time:>5}]:\tDIED")
         self.sim.queue = [(p1, p2, u) for p1, p2, u in self.sim.queue if u not in ['enemy', 'enemy_special']]
         heapify(self.sim.queue)
         self.sim.hunter.total_kills += 1
@@ -240,13 +249,10 @@ class Enemy:
     def kill(self) -> None:
         """Kills the unit.
 
-        Currently only used for Trample, which is a guaranteed kill. on_death() is not called here to suppress logging,
-        and because the trampled units attacks are not queued yet, so this would take up unnecessary processing.
+        Currently only used for Trample, which is a guaranteed kill.
         """
         self.hp = 0
-        self.sim.hunter.total_kills += 1
-        self.sim.hunter.total_attacks += 1
-        self.sim.hunter.on_kill()
+        self.on_death(suppress_logging=True)
 
     ### UTILITY
 

--- a/hunter-sim/units.py
+++ b/hunter-sim/units.py
@@ -257,7 +257,7 @@ class Enemy:
         Returns:
             str: The stats as a formatted string.
         """
-        return f'[{self.name:>{unit_name_spacing}}]:\t[HP:{(str(round(self.hp, 2)) + "/" + str(round(self.max_hp, 2))):>18}] [AP:{self.power:>7.2f}] [Regen:{self.regen:>6.2f}] [DR: {self.damage_reduction:>6.4f}] [Evasion: {self.evade_chance:>6.4f}] [Effect: ------] [CHC: {self.special_chance:>6.4f}] [CHD: {self.special_damage:>5.2f}] [Speed:{self.speed:>5.2f}]{(f" [Speed2:{self.speed2:>6.2f}]") if self.has_special else ""}'
+        return f'[{self.name:>{unit_name_spacing}}]:\t[HP:{(str(round(self.hp, 2)) + "/" + str(round(self.max_hp, 2))):>18}] [AP:{self.power:>8.2f}] [Regen:{self.regen:>7.2f}] [DR: {self.damage_reduction:>6.2%}] [Evasion: {self.evade_chance:>6.2%}] [Effect: ------] [CHC: {self.special_chance:>6.2%}] [CHD: {self.special_damage:>5.2f}] [Speed:{self.speed:>5.2f}]{(f" [Speed2:{self.speed2:>6.2f}]") if self.has_special else ""}'
 
 
 class Boss(Enemy):

--- a/hunter-sim/units.py
+++ b/hunter-sim/units.py
@@ -206,6 +206,7 @@ class Enemy:
         self.heal_hp(regen_value, 'regen')
         # handle death from Ozzy's Gift of Medusa
         if self.is_dead():
+            self.sim.hunter.medusa_kills += 1
             self.on_death()
 
     def stun(self, duration: float) -> None:


### PR DESCRIPTION
- changed unit and hunter stat display from 0-1 to percentages
- fixed incorrect application of innovation node 3 effect
- added new relics R16/17
- added functions to hunter to enable loading builds from file and converting hunter instances to dicts
- added `max` as viable input for inscryption levels in configs (resolve #26)
- fixed stage 0 never receiving LL procs
- fixed missing loot from helltouch, medusa and trample kills
- added helltouch, medusa and trample kills as combat stats
- modified trample to include passage of time and account for crits